### PR TITLE
remove css-wordpress dependency

### DIFF
--- a/templates/includes/footer.html.twig
+++ b/templates/includes/footer.html.twig
@@ -5,7 +5,6 @@
 
             <div class="govuk-footer__section">
                 <a class="govuk-footer__link logo" href="/"><img src="/assets/images/CCS_WHITE_SML_AW.png" alt="Go to the CCS homepage"></a>
-
                 <ul class="list list--inline social-links">
                     <li>
                         <a href="https://twitter.com/gov_procurement" class="govuk-footer__link">
@@ -20,36 +19,120 @@
                             </span> <span class="visuallyhidden">Connect with us on LinkedIn</span></a>
                     </li>
                 </ul>
-
                 <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">©
                     Crown copyright</a>
+            </div>
+
+            <div class="govuk-footer__section">
+                <h2 class="govuk-footer__heading govuk-!-font-size-22">Sitemap</h2>
+                <ul class="govuk-list govuk-!-font-size-18">
+                    <li>
+                        <a class="govuk-footer__link" href="https://www.crowncommercial.gov.uk/agreements">Search frameworks</a>
+                    </li>
+                    <li>
+                        <a class="govuk-footer__link" href="https://www.crowncommercial.gov.uk/suppliers">Search suppliers</a>
+                    </li>
+                    <li>
+                        <a class="govuk-footer__link" href="https://www.crowncommercial.gov.uk/agreements/upcoming">Upcoming deals</a>
+                    </li>
+                    <li>
+                        <a class="govuk-footer__link" href="https://www.crowncommercial.gov.uk/help-and-support/how-to-buy/">Buy through CCS</a>
+                    </li>
+                    <li>
+                        <a class="govuk-footer__link" href="https://www.crowncommercial.gov.uk/help-and-support/">Help and support</a>
+                    </li>
+                    <li>
+                        <a class="govuk-footer__link" href="https://www.crowncommercial.gov.uk/about-ccs/">About CCS</a>
+                    </li>
+                    <li>
+                        <a class="govuk-footer__link" href="https://www.crowncommercial.gov.uk/contact">Contact us</a>
+                    </li>
+                    <li>
+                        <a class="govuk-footer__link" href="https://www.crowncommercial.gov.uk/news">News</a>
+                    </li>
+                </ul>
+            </div>
+
+            <div class="govuk-footer__section">
+
+                <h2 class="govuk-footer__heading govuk-!-font-size-22">Quick links</h2>
+
+                <ul class="govuk-list govuk-!-font-size-18">
+                    <li>
+                        <a class="govuk-footer__link" href="https://purchasingplatform.crowncommercial.gov.uk/mp-welcome">Purchasing platform</a>
+                    </li>
+                    <li>
+                        <a class="govuk-footer__link" href="https://www.digitalmarketplace.service.gov.uk/">Digital marketplace</a>
+                    </li>
+                    <li>
+                        <a class="govuk-footer__link" href="https://buyers.procserveonline.com/admin/login/auth?marketplace=bootstrap-gem">eMarketplace</a>
+                    </li>
+                    <li>
+                        <a class="govuk-footer__link" href="https://ccsheretohelp.uk/products-services/buildings/energy/">Energy</a>
+                    </li>
+                    <li>
+                        <a class="govuk-footer__link" href="https://fleetportal.crowncommercial.gov.uk/login.mth">Fleet</a>
+                    </li>
+                    <li>
+                        <a class="govuk-footer__link" href="https://travel.crowncommercial.gov.uk/">Travel</a>
+                    </li>
+                    <li>
+                        <a class="govuk-footer__link" href="https://www.gov.uk/contracts-finder">Contracts Finder</a>
+                    </li>
+                    <li>
+                        <a class="govuk-footer__link" href="https://www.crowncommercial.gov.uk/esourcing-register">eSourcing</a>
+                    </li>
+                    <li>
+                        <a class="govuk-footer__link" href="https://www.crowncommercial.gov.uk/esourcing-training">Register for eSourcing training</a>
+                    </li>
+                    <li>
+                        <a class="govuk-footer__link" href="http://ted.europa.eu/TED/main/HomePage.do">Tenders Electronic Daily (TED)</a>
+                    </li>
+                    <li>
+                        <a class="govuk-footer__link" href="https://www.reportmi.crowncommercial.gov.uk/">Submit your MI returns</a>
+                    </li>
+                    <li>
+                        <a class="govuk-footer__link" href="https://status.crowncommercial.gov.uk/">Service Status</a>
+                    </li>
+                </ul>
+
 
             </div>
 
             <div class="govuk-footer__section">
 
-                {{ render(controller(
-                    'App\\Controller\\MenuController::menu',
-                    { 'id': 23, 'currentPath': app.request.pathinfo, 'templatePath': 'menus/footer-menu.html.twig' }
-                )) }}
+                <h2 class="govuk-footer__heading govuk-!-font-size-22">About and contact</h2>
 
-            </div>
+                <ul class="govuk-list govuk-!-font-size-18">
+                    <li>
+                        <a class="govuk-footer__link" href="https://www.crowncommercial.gov.uk/about-ccs/">About CCS</a>
+                    </li>
+                    <li>
+                        <a class="govuk-footer__link" href="https://www.crowncommercial.gov.uk/contact">Contact CCS</a>
+                    </li>
+                    <li>
+                        <a class="govuk-footer__link" href="https://www.crowncommercial.gov.uk/make-a-complaint/">Make a complaint</a>
+                    </li>
+                    <li>
+                        <a class="govuk-footer__link" href="https://www.gov.uk/government/organisations/crown-commercial-service/about/recruitment">Careers</a>
+                    </li>
+                    <li>
+                        <a class="govuk-footer__link" href="https://www.crowncommercial.gov.uk/terms-and-conditions/">Terms and conditions</a>
+                    </li>
+                    <li>
+                        <a class="govuk-footer__link" href="https://www.crowncommercial.gov.uk/cookie-policy/">Cookie policy</a>
+                    </li>
+                    <li>
+                        <a class="govuk-footer__link" href="https://www.gov.uk/government/organisations/crown-commercial-service">Corporate information</a>
+                    </li>
+                    <li>
+                        <a class="govuk-footer__link" href="https://www.gov.uk/government/publications/crown-commercial-service-privacy-notice">Privacy notice</a>
+                    </li>
+                    <li>
+                        <a class="govuk-footer__link" href="https://www.crowncommercial.gov.uk/accessibility-statement">Accessibility</a>
+                    </li>
+                </ul>
 
-            <div class="govuk-footer__section">
-
-                {{ render(controller(
-                    'App\\Controller\\MenuController::menu',
-                    { 'id': 24, 'currentPath': app.request.pathinfo, 'templatePath': 'menus/footer-menu.html.twig' }
-                )) }}
-
-            </div>
-
-            <div class="govuk-footer__section">
-
-                {{ render(controller(
-                    'App\\Controller\\MenuController::menu',
-                    { 'id': 25, 'currentPath': app.request.pathinfo, 'templatePath': 'menus/footer-menu.html.twig' }
-                )) }}
 
             </div>
 

--- a/templates/includes/header.html.twig
+++ b/templates/includes/header.html.twig
@@ -25,19 +25,50 @@
             </button>
 
             {% block mainnavigation %}
-            <nav class="global-navigation" data-toggle="nav" data-app-uri="{{ app.request.uri }}" data-app-pathinfo="{{ app.request.pathinfo }}">
+                <nav class="global-navigation" data-toggle="nav" data-app-uri="http://localhost:8001/guided-match/example" data-app-pathinfo="/guided-match/example" aria-hidden="false">
 
-                {{ render(controller(
-                    'App\\Controller\\MenuController::menu',
-                    { 'id': 22, 'currentPath': app.request.pathinfo, 'templatePath': 'menus/secondary-menu.html.twig' }
-                )) }}
+                    <ul class="nav-list nav-list--secondary">
+                        <li class="nav-list__item">
+                            <a class="nav-list__link  " href="https://www.crowncommercial.gov.uk/about-ccs/">About CCS</a>
+                        </li>
+                        <li class="nav-list__item">
+                            <a class="nav-list__link  " href="https://www.crowncommercial.gov.uk/contact">Contact CCS</a>
+                        </li>
+                        <li class="nav-list__item">
+                            <a class="nav-list__link  " href="https://www.crowncommercial.gov.uk/news">News</a>
+                        </li>
+                        <li class="nav-list__item">
+                            <a class="nav-list__link  " href="https://www.crowncommercial.gov.uk/events">Events</a>
+                        </li>
+                        <li class="nav-list__item">
+                            <a class="nav-list__link  " href="https://www.crowncommercial.gov.uk/help-and-support/">Help and support</a>
+                        </li>
+                        <li class="nav-list__item">
+                            <a class="nav-list__link  " href="tel:03454102222">Helpline: 0345 410 2222</a>
+                        </li>
+                    </ul>
 
-                {{ render(controller(
-                    'App\\Controller\\MenuController::menu',
-                    { 'id': 21, 'currentPath': app.request.pathinfo, 'templatePath': 'menus/primary-menu.html.twig' }
-                )) }}
 
-            </nav>
+                    <ul class="nav-list nav-list--primary">
+                        <li class="nav-list__item">
+                            <a class="nav-list__link  " href="https://www.crowncommercial.gov.uk/agreements">Search frameworks</a>
+                        </li>
+                        <li class="nav-list__item">
+                            <a class="nav-list__link  " href="https://www.crowncommercial.gov.uk/suppliers">Search suppliers</a>
+                        </li>
+                        <li class="nav-list__item">
+                            <a class="nav-list__link  " href="https://www.crowncommercial.gov.uk/agreements/upcoming">Upcoming deals</a>
+                        </li>
+                        <li class="nav-list__item">
+                            <a class="nav-list__link  " href="https://www.crowncommercial.gov.uk/products-and-services/">Products and Services</a>
+                        </li>
+                        <li class="nav-list__item">
+                            <a class="nav-list__link  " href="https://www.crowncommercial.gov.uk/products-and-services/sectors">Sectors</a>
+                        </li>
+                    </ul>
+
+
+                </nav>
 
             {% endblock %}
         </div>


### PR DESCRIPTION
# Related story:
 - [SFC-158](https://crowncommercialservice.atlassian.net/browse/SFC-158)

# Details related to the functionality added:
 - removed ccs-wordpress calls and replaced them with static data 🤟🏼
 - changed the URLs of the menu to point to the pages of crown commercial service
