### PR TITLE
SFAT-179 - updated dev environment URLs following refactor

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -28,7 +28,7 @@ SEARCH_API_BASE_URL=''
 APP_CMS_BASE_URL=''
 
 #URL of website (front-end app)
-APP_BASE_URL=https://kt363e9i9g.execute-api.eu-west-2.amazonaws.com/dev/scale/buyer
+APP_BASE_URL=https://584xzj6rf3.execute-api.eu-west-2.amazonaws.com/dev/scale/buyer
 
 #URL of Guide Match API
-GUIDE_MATCH_DECISION_TREE_API=https://kt363e9i9g.execute-api.eu-west-2.amazonaws.com/dev/scale/guided-match-service
+GUIDE_MATCH_DECISION_TREE_API=https://584xzj6rf3.execute-api.eu-west-2.amazonaws.com/dev/scale/guided-match-service


### PR DESCRIPTION
Hi Adrian - after rebuilding the environments I noticed that BuyerUI seems to still be pointing to the old DEV environment (I thought we were going to change it to SBX5)?

I just wanted to check if updating the API URLs fixed it - so I created this branch and updated the URL for the DEV environment and deployed to SBX5 - this seems to work. 

You don't have to approve this merge request if you prefer to make the changes a different way - that's fine. This is just a convenience - and means I can deploy from this branch temporarily tomorrow if the testers are blocked (as I think you guys are on holiday). This is just a stop gap fix. The environment variables are all in place now and available to use. 