### PR TITLE
update url for Guide Match api, to use value from ECS  or from .env

### DIFF
--- a/.env
+++ b/.env
@@ -29,20 +29,6 @@ APP_CMS_BASE_URL=''
 
 #URL of website (front-end app)
 APP_BASE_URL=https://kt363e9i9g.execute-api.eu-west-2.amazonaws.com/dev/scale/buyer
+
 #URL of Guide Match API
-GUIDE_MATCH_DECISION_TREE_API=https://7tbw7u5f0k.execute-api.eu-west-2.amazonaws.com/dev/scale/guided-match-service
-
-GUIDED_MATCH_SERVICE_ROOT_URL = 'https://z59rps5ew4.execute-api.eu-west-2.amazonaws.com/test'
-
-#ElasticSearch config
-ELASTIC_TRANSPORT='http'
-ELASTIC_HOST='127.0.0.1'
-ELASTIC_PORT=9200
-
-# Must use a unique name for each instance to avoid data leaking between indexes
-ELASTIC_SUFFIX='local'
-### Application configuration
-#APP_API_BASE_URL=http://127.0.0.1:9031/wp-json/
-
-#URL of CMS
-#APP_CMS_BASE_URL=''
+GUIDED_MATCH_SERVICE_ROOT_URL=https://z59rps5ew4.execute-api.eu-west-2.amazonaws.com/sbx5

--- a/.env.dev
+++ b/.env.dev
@@ -31,5 +31,4 @@ APP_CMS_BASE_URL=''
 APP_BASE_URL=https://584xzj6rf3.execute-api.eu-west-2.amazonaws.com/dev/scale/buyer
 
 #URL of Guide Match API
-GUIDE_MATCH_DECISION_TREE_API=https://584xzj6rf3.execute-api.eu-west-2.amazonaws.com/dev/scale/guided-match-service
-GUIDED_MATCH_SERVICE_ROOT_URL = 'https://z59rps5ew4.execute-api.eu-west-2.amazonaws.com/test'
+GUIDED_MATCH_SERVICE_ROOT_URL=https://z59rps5ew4.execute-api.eu-west-2.amazonaws.com/sbx5

--- a/src/Controller/GuideMatchBackToPreviousController.php
+++ b/src/Controller/GuideMatchBackToPreviousController.php
@@ -26,7 +26,7 @@ class GuideMatchBackToPreviousController extends AbstractController
 
 
         $httpClient = HttpClient::create();
-        $api = new GuideMatchJourneyApi($httpClient, getenv('GUIDE_MATCH_DECISION_TREE_API'));
+        $api = new GuideMatchJourneyApi($httpClient, getenv('GUIDED_MATCH_SERVICE_ROOT_URL'));
         $model = new GuideMatchJourneyModel($api);
        
         $lastPage = $gPage -2 > 1 ? $gPage -2 : 0;

--- a/src/Controller/GuideMatchJourneyController.php
+++ b/src/Controller/GuideMatchJourneyController.php
@@ -16,7 +16,7 @@ class GuideMatchJourneyController extends AbstractController
     {
         $searchBy = $request->query->get('q');
         $httpClient = HttpClient::create();
-        $api = new GuideMatchJourneyApi($httpClient, getenv('GUIDE_MATCH_DECISION_TREE_API'));
+        $api = new GuideMatchJourneyApi($httpClient, getenv('GUIDED_MATCH_SERVICE_ROOT_URL'));
 
         $response = [];
 

--- a/src/Controller/StartJourneyController.php
+++ b/src/Controller/StartJourneyController.php
@@ -17,7 +17,7 @@ class StartJourneyController extends AbstractController
         $searchBy = $request->query->get('q');
 
         $httpClient = HttpClient::create();
-        $api = new GuideMatchJourneyApi($httpClient, getenv('GUIDE_MATCH_DECISION_TREE_API'));
+        $api = new GuideMatchJourneyApi($httpClient, getenv('GUIDED_MATCH_SERVICE_ROOT_URL'));
        
         $model = new GuideMatchJourneyModel($api);
         $model->startJourney($journeyUuid, $searchBy);

--- a/src/GuideMatchApi/GuideMatchJourneyApi.php
+++ b/src/GuideMatchApi/GuideMatchJourneyApi.php
@@ -61,7 +61,7 @@ class GuideMatchJourneyApi
             throw new Exception('Invalid arguments of method');
         }
 
-        $response = $this->httpClient->request('POST', $this->baseApiUrl."/journeys/{$journeyId}", [
+        $response = $this->httpClient->request('POST', $this->baseApiUrl."/scale/guided-match-service/journeys/{$journeyId}", [
             'json' => ['searchTerm' => $searchBy]
         ]);
 
@@ -121,13 +121,13 @@ class GuideMatchJourneyApi
         ) {
             throw new Exception('Invalid arguments of method');
         }
-
+       
         $data = [
             "id"=> $questionsUuid,
             'answers' => $questionResponse
         ];
         
-        $response = $this->httpClient->request('POST', "{$this->baseApiUrl}/journey-instances/{$journeyUuid}/questions/{$questionsUuid}", [
+        $response = $this->httpClient->request('POST', "{$this->baseApiUrl}/scale/guided-match-service/journey-instances/{$journeyUuid}/questions/{$questionsUuid}", [
             'json' => [$data]
         ]);
         try {
@@ -150,7 +150,7 @@ class GuideMatchJourneyApi
 
     public function getJourneySummary($journeyUuid)
     {
-        $response = $this->httpClient->request('GET', "{$this->baseApiUrl}/ourney-summaries/{$journeyUuid}");
+        $response = $this->httpClient->request('GET', "{$this->baseApiUrl}/journey-summaries/{$journeyUuid}");
 
         try {
             $content = $response->getContent();


### PR DESCRIPTION
Update url Guide Match API from env  configuration.. I've used the same name as on AWS/ECS so it should be override with the value from AWS,  if I tested correctly