### PR TITLE
Feature/sfc 1082 upgrade base image hide server details

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,8 +39,8 @@ RUN echo "ServerName localhost:$PORT" >> /etc/apache2/apache2.conf
 RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/conf.d/php.ini"
 RUN sed -i -e 's/expose_php = On/expose_php = Off/' "$PHP_INI_DIR/conf.d/php.ini"
 
-# increase memory limit to 2GB
-RUN echo 'memory_limit = 2048M' >> /usr/local/etc/php/conf.d/docker-php-memlimit.ini;
+# increase memory limit to 2.5GB
+RUN echo 'memory_limit = 2560M' >> /usr/local/etc/php/conf.d/docker-php-memlimit.ini;
 RUN echo 'opcache.preload=/var/www/html/ccs/var/cache/prod/srcApp_KernelProdContainer.preload.php' >> /usr/local/etc/php/conf.d/docker-php-memlimit.ini;
 RUN echo 'opcache.memory_consumption=256' >> /usr/local/etc/php/conf.d/docker-php-memlimit.ini;
 RUN echo 'opcache.max_accelerated_files=20000' >> /usr/local/etc/php/conf.d/docker-php-memlimit.ini;

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,8 +43,8 @@ RUN echo "ServerName localhost:$PORT" >> /etc/apache2/apache2.conf
 # Workaround:
 RUN echo 'expose_php = Off' >> "$PHP_INI_DIR/conf.d/security.ini"
 
-# increase memory limit to 2.5GB
-RUN echo 'memory_limit = 2560M' >> "$PHP_INI_DIR/conf.d/docker-php-memlimit.ini"
+# increase memory limit to 2GB
+RUN echo 'memory_limit = 2048M' >> "$PHP_INI_DIR/conf.d/docker-php-memlimit.ini"
 RUN echo 'opcache.preload=/var/www/html/ccs/var/cache/prod/srcApp_KernelProdContainer.preload.php' >> "$PHP_INI_DIR/conf.d/docker-php-memlimit.ini"
 RUN echo 'opcache.memory_consumption=256' >> "$PHP_INI_DIR/conf.d/docker-php-memlimit.ini"
 RUN echo 'opcache.max_accelerated_files=20000' >> "$PHP_INI_DIR/conf.d/docker-php-memlimit.ini"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.4.4-apache
+FROM php:7.4.10-apache
 
 ENV PORT 9030
 
@@ -19,6 +19,11 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local
 ENV APACHE_DOCUMENT_ROOT = /var/www/html/ccs/public
 RUN sed -ri -e 's!/var/www/html!/var/www/html/ccs/public!g' /etc/apache2/sites-available/*.conf
 RUN sed -ri -e 's!/var/www/!/var/www/html/ccs/public!g' /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf
+
+# Remove server version from 'Server' header and footer signature
+RUN sed -i -e 's/ServerTokens OS/ServerTokens Prod/' /etc/apache2/conf-enabled/security.conf
+RUN sed -i -e 's/ServerSignature On/ServerSignature Off/' /etc/apache2/conf-enabled/security.conf
+
 RUN a2enmod rewrite
 RUN a2enmod php7
 
@@ -30,6 +35,9 @@ RUN echo "ServerName localhost:$PORT" >> /etc/apache2/apache2.conf
 
 #COPY ./composer.json ./
 
+# Configure PHP
+RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
+RUN sed -i -e 's/expose_php = On/expose_php = Off/' "$PHP_INI_DIR/php.ini"
 
 # increase memory limit to 2GB
 RUN echo 'memory_limit = 2048M' >> /usr/local/etc/php/conf.d/docker-php-memlimit.ini;

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,8 +36,8 @@ RUN echo "ServerName localhost:$PORT" >> /etc/apache2/apache2.conf
 #COPY ./composer.json ./
 
 # Configure PHP
-RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
-RUN sed -i -e 's/expose_php = On/expose_php = Off/' "$PHP_INI_DIR/php.ini"
+# RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
+# RUN sed -i -e 's/expose_php = On/expose_php = Off/' "$PHP_INI_DIR/php.ini"
 
 # increase memory limit to 2GB
 RUN echo 'memory_limit = 2048M' >> /usr/local/etc/php/conf.d/docker-php-memlimit.ini;
@@ -61,8 +61,6 @@ RUN npm install
 
 # restart apache
 RUN service apache2 restart
-
-RUN chmod 777 ./public/speedTest.log
 
 VOLUME /var/www/html/ccs
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,13 +41,13 @@ RUN echo "ServerName localhost:$PORT" >> /etc/apache2/apache2.conf
 # RUN sed -i -e 's/expose_php = On/expose_php = Off/' "$PHP_INI_DIR/conf.d/php.ini"
 
 # Workaround:
-RUN echo 'expose_php = Off' >> conf.d/security.ini
+RUN echo 'expose_php = Off' >> "$PHP_INI_DIR/conf.d/security.ini"
 
 # increase memory limit to 2.5GB
-RUN echo 'memory_limit = 2560M' >> /usr/local/etc/php/conf.d/docker-php-memlimit.ini;
-RUN echo 'opcache.preload=/var/www/html/ccs/var/cache/prod/srcApp_KernelProdContainer.preload.php' >> /usr/local/etc/php/conf.d/docker-php-memlimit.ini;
-RUN echo 'opcache.memory_consumption=256' >> /usr/local/etc/php/conf.d/docker-php-memlimit.ini;
-RUN echo 'opcache.max_accelerated_files=20000' >> /usr/local/etc/php/conf.d/docker-php-memlimit.ini;
+RUN echo 'memory_limit = 2560M' >> "$PHP_INI_DIR/conf.d/docker-php-memlimit.ini"
+RUN echo 'opcache.preload=/var/www/html/ccs/var/cache/prod/srcApp_KernelProdContainer.preload.php' >> "$PHP_INI_DIR/conf.d/docker-php-memlimit.ini"
+RUN echo 'opcache.memory_consumption=256' >> "$PHP_INI_DIR/conf.d/docker-php-memlimit.ini"
+RUN echo 'opcache.max_accelerated_files=20000' >> "$PHP_INI_DIR/conf.d/docker-php-memlimit.ini"
 
 #copy project into container
 COPY ./ ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,9 +35,13 @@ RUN echo "ServerName localhost:$PORT" >> /etc/apache2/apache2.conf
 
 #COPY ./composer.json ./
 
+# TODO: Recommended but causes OOM error when loading composer during image build
 # Configure PHP (and use recommended production settings - see https://hub.docker.com/_/php)
-RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/conf.d/php.ini"
-RUN sed -i -e 's/expose_php = On/expose_php = Off/' "$PHP_INI_DIR/conf.d/php.ini"
+# RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/conf.d/php.ini"
+# RUN sed -i -e 's/expose_php = On/expose_php = Off/' "$PHP_INI_DIR/conf.d/php.ini"
+
+# Workaround:
+RUN echo 'expose_php = Off' >> conf.d/security.ini
 
 # increase memory limit to 2.5GB
 RUN echo 'memory_limit = 2560M' >> /usr/local/etc/php/conf.d/docker-php-memlimit.ini;

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,9 +35,9 @@ RUN echo "ServerName localhost:$PORT" >> /etc/apache2/apache2.conf
 
 #COPY ./composer.json ./
 
-# Configure PHP
-# RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
-# RUN sed -i -e 's/expose_php = On/expose_php = Off/' "$PHP_INI_DIR/php.ini"
+# Configure PHP (and use recommended production settings - see https://hub.docker.com/_/php)
+RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/conf.d/php.ini"
+RUN sed -i -e 's/expose_php = On/expose_php = Off/' "$PHP_INI_DIR/conf.d/php.ini"
 
 # increase memory limit to 2GB
 RUN echo 'memory_limit = 2048M' >> /usr/local/etc/php/conf.d/docker-php-memlimit.ini;


### PR DESCRIPTION
Now deployed to SBX2: https://sbx2.scale.crowncommercial.gov.uk/find-a-commercial-agreement/landing-page?q=linen
Observe the absence of Apache server version and `X-Powered-By` showing the PHP version in the response headers.  Bit of fiddling around so as not to break either a) the codebuild project and b) the website!  Left the block regarding `php.ini-production` in there commented out, as this is the recommended approach so we should try to move towards using it (it caused OOM errors with composer during the build for some reason - stricter memory config I guess).