### PR TITLE
Upgrade base php-apache image and hide Apache / php versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.4.4-apache
+FROM php:7.4.10-apache
 
 ENV PORT 9030
 
@@ -19,6 +19,11 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local
 ENV APACHE_DOCUMENT_ROOT = /var/www/html/ccs/public
 RUN sed -ri -e 's!/var/www/html!/var/www/html/ccs/public!g' /etc/apache2/sites-available/*.conf
 RUN sed -ri -e 's!/var/www/!/var/www/html/ccs/public!g' /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf
+
+# Remove server version from 'Server' header and footer signature
+RUN sed -i -e 's/ServerTokens OS/ServerTokens Prod/' /etc/apache2/conf-enabled/security.conf
+RUN sed -i -e 's/ServerSignature On/ServerSignature Off/' /etc/apache2/conf-enabled/security.conf
+
 RUN a2enmod rewrite
 RUN a2enmod php7
 
@@ -30,12 +35,19 @@ RUN echo "ServerName localhost:$PORT" >> /etc/apache2/apache2.conf
 
 #COPY ./composer.json ./
 
+# TODO: Recommended but causes OOM error when loading composer during image build
+# Configure PHP (and use recommended production settings - see https://hub.docker.com/_/php)
+# RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/conf.d/php.ini"
+# RUN sed -i -e 's/expose_php = On/expose_php = Off/' "$PHP_INI_DIR/conf.d/php.ini"
+
+# Workaround:
+RUN echo 'expose_php = Off' >> "$PHP_INI_DIR/conf.d/security.ini"
 
 # increase memory limit to 2GB
-RUN echo 'memory_limit = 2048M' >> /usr/local/etc/php/conf.d/docker-php-memlimit.ini;
-RUN echo 'opcache.preload=/var/www/html/ccs/var/cache/prod/srcApp_KernelProdContainer.preload.php' >> /usr/local/etc/php/conf.d/docker-php-memlimit.ini;
-RUN echo 'opcache.memory_consumption=256' >> /usr/local/etc/php/conf.d/docker-php-memlimit.ini;
-RUN echo 'opcache.max_accelerated_files=20000' >> /usr/local/etc/php/conf.d/docker-php-memlimit.ini;
+RUN echo 'memory_limit = 2048M' >> "$PHP_INI_DIR/conf.d/docker-php-memlimit.ini"
+RUN echo 'opcache.preload=/var/www/html/ccs/var/cache/prod/srcApp_KernelProdContainer.preload.php' >> "$PHP_INI_DIR/conf.d/docker-php-memlimit.ini"
+RUN echo 'opcache.memory_consumption=256' >> "$PHP_INI_DIR/conf.d/docker-php-memlimit.ini"
+RUN echo 'opcache.max_accelerated_files=20000' >> "$PHP_INI_DIR/conf.d/docker-php-memlimit.ini"
 
 #copy project into container
 COPY ./ ./
@@ -53,8 +65,6 @@ RUN npm install
 
 # restart apache
 RUN service apache2 restart
-
-RUN chmod 777 ./public/speedTest.log
 
 VOLUME /var/www/html/ccs
 


### PR DESCRIPTION
Identical changes to https://github.com/Crown-Commercial-Service/ccs-scale-ui/pull/279 - just targeted separately at develop so as not to inadvertently take any R1.1 changes with it (now been decided this needs to be in PRD for go-live rather than R1.1)