### PR TITLE
Remove type hint to fix route issue

### DIFF
--- a/src/Models/UserAnswers.php
+++ b/src/Models/UserAnswers.php
@@ -116,7 +116,7 @@ class UserAnswers
         return $answers;
     }
 
-    public function addSelectedJourneyToUserAnswers( string $searchBy, string $journeyId, array $journeys, string $selectedDomain){
+    public function addSelectedJourneyToUserAnswers( string $searchBy, string $journeyId, array $journeys, $selectedDomain){
 
         if(
             empty($journeyId) &&


### PR DESCRIPTION
To replicate issue -Go through Journey until the end > click contact CCS > click on change answer > error when trying to reach end of journey 

It occurs because of selected domain null value which isn't a string so removed type hint to fix issue. 